### PR TITLE
Update missing registry parameters in spec

### DIFF
--- a/content/docs/2/reference-iofogctl/reference-registry.md
+++ b/content/docs/2/reference-iofogctl/reference-registry.md
@@ -14,16 +14,20 @@ spec:
   email: user@domain.com
   requiresCert: false
   certificate: ''
+  private: false
+  id: 42
 ```
 
-| Field        | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| url          | Registry url                                          |
-| username     | Username                                              |
-| password     | Password                                              |
-| email        | Email                                                 |
-| certificate  | (Optional) Certificate to be used by the registry     |
-| requiresCert | (Optional) Does the repository requires a certificate |
+| Field        | Description                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------|
+| url          | Registry url                                                                           |
+| username     | Username                                                                               |
+| password     | Password                                                                               |
+| email        | Email                                                                                  |
+| certificate  | (Optional) Certificate to be used by the registry                                      |
+| id           | (Optional) An integer that is used to identify the registry                            |
+| private      | (Optional) true|false If true, authenticate with the registy via username and password |
+| requiresCert | (Optional) Does the repository requires a certificate                                  |
 
 <aside class="notifications contribute">
   <h3><img src="/images/icos/ico-github.svg" alt="">See anything wrong with the document? Help us improve it!</h3>


### PR DESCRIPTION
TL;DR
Some undocumented specs for the registry kind.

- id: Used to set the numerical identifier of the registry, to be called in the microservice spec images/registry
- private: Must be set to true if using a registry that requires authentication

<!--
********************************************************************************
IMPORTANT: the documentation is versioned, so most changes should be made to the
files in content/docs/next which will then get published in the next major or
minor release. You are welcome to also back-port the change to older versions,
if it's applicable.
********************************************************************************
Thank you for your contribution!
Contributor Guide: https://iofog.org/docs/contributing/guidelines.html
Code of Conduct: https://iofog.org/docs/contributing/code-of-conduct.html
-->
